### PR TITLE
Fix array editing in the CLI

### DIFF
--- a/libcobblersignatures/cli.py
+++ b/libcobblersignatures/cli.py
@@ -133,10 +133,9 @@ edit_add_os_version_1 = [
 
 edit_add_os_version_2 = [
     {
-        'type': 'select',
+        'type': 'text',
         'name': 'edit_add_os_version_2',
-        'message': "What shall be the name of the new version?",
-        'choices': [""]
+        'message': "What shall be the name of the new version?"
     }]
 
 edit_remove_os_version_1 = [
@@ -600,18 +599,16 @@ def edit_menu_breed_version_info():
         my_osversion.kernel_arch_regex = new_value_kernel_arch_regex
     elif choice_edit_information_os_version.startswith("supported_arches"):
         result_supported_arches_choice = edit_menu_version_add_remove_edit.ask()
-        choice_result_supported_arches_choice = result_supported_arches_choice \
-            .get("edit_menu_version_add_remove_edit", "")
-        if choice_result_supported_arches_choice == "Add":
+        if result_supported_arches_choice == "Add":
             new_value_supported_arches = edit_menu_breed_version_supported_arches_add.ask()
             my_osversion.supported_arches.append(new_value_supported_arches)
-        elif choice_result_supported_arches_choice == "Edit":
+        elif result_supported_arches_choice == "Edit":
             new_value_edit_arches = questionary.prompt(edit_menu_breed_version_supported_arches_edit)
             index_to_change = my_osversion.supported_arches \
                 .index(new_value_edit_arches["edit_menu_breed_version_supported_arches_edit"])
             my_osversion.supported_arches[index_to_change] = \
                 new_value_edit_arches["edit_menu_breed_version_supported_arches_edit_new"]
-        elif choice_result_supported_arches_choice == "Remove":
+        elif result_supported_arches_choice == "Remove":
             value_to_be_removed = edit_menu_breed_version_supported_arches_delete.ask()
             my_osversion.supported_arches.remove(value_to_be_removed)
         else:
@@ -619,18 +616,17 @@ def edit_menu_breed_version_info():
         # TODO: Validation of arches (only with warning)
     elif choice_edit_information_os_version == "supported_repo_breeds":
         result_repo_breeds_choice = edit_menu_version_add_remove_edit.ask()
-        choice_result_repo_breeds_choice = result_repo_breeds_choice.get("edit_menu_version_add_remove_edit", "")
-        if choice_result_repo_breeds_choice == "Add":
+        if result_repo_breeds_choice == "Add":
             new_value_supported_repo_breed = edit_menu_breed_version_supported_repo_breeds_add.ask()
             my_osversion.supported_repo_breeds.append(new_value_supported_repo_breed)
-        elif choice_result_repo_breeds_choice == "Edit":
+        elif result_repo_breeds_choice == "Edit":
             new_value_edit_supported_repo_breeds = questionary.prompt(
                 edit_menu_breed_version_supported_repo_breeds_edit)
             index_to_change = my_osversion.supported_repo_breeds.index(
                 new_value_edit_supported_repo_breeds["edit_menu_breed_version_supported_repo_breeds_edit"])
             my_osversion.supported_repo_breeds[index_to_change] = \
                 new_value_edit_supported_repo_breeds["edit_menu_breed_version_supported_repo_breeds_edit_new"]
-        elif choice_result_repo_breeds_choice == "Remove":
+        elif result_repo_breeds_choice == "Remove":
             value_to_be_removed = edit_menu_breed_version_supported_repo_breeds_delete.ask()
             my_osversion.supported_repo_breeds.remove(value_to_be_removed)
         else:
@@ -657,17 +653,16 @@ def edit_menu_breed_version_info():
         my_osversion.kernel_options_post = new_value_kernel_options_post
     elif choice_edit_information_os_version.startswith("boot_files"):
         result_boot_files_choice = edit_menu_version_add_remove_edit.ask()
-        choice_result_boot_files_choice = result_boot_files_choice.get("edit_menu_version_add_remove_edit", "")
-        if choice_result_boot_files_choice == "Add":
+        if result_boot_files_choice == "Add":
             new_value_boot_files_add = edit_menu_breed_version_boot_files_add.ask()
             my_osversion.boot_files.append(new_value_boot_files_add)
-        elif choice_result_boot_files_choice == "Edit":
+        elif result_boot_files_choice == "Edit":
             new_value_edit_boot_files = questionary.prompt(edit_menu_breed_version_boot_files_edit)
             index_to_change = my_osversion.boot_files \
                 .index(new_value_edit_boot_files["edit_menu_breed_version_boot_files_edit"])
             my_osversion.boot_files[index_to_change] = \
                 new_value_edit_boot_files["edit_menu_breed_version_boot_files_edit_new"]
-        elif choice_result_boot_files_choice == "Remove":
+        elif result_boot_files_choice == "Remove":
             value_to_be_removed = edit_menu_breed_version_boot_files_delete.ask()
             my_osversion.boot_files.remove(value_to_be_removed)
         else:

--- a/libcobblersignatures/cli.py
+++ b/libcobblersignatures/cli.py
@@ -200,6 +200,7 @@ edit_menu_breed_version_signatures_add = questionary.text(
 
 edit_menu_breed_version_signatures_edit = [
     {
+        # TODO: Change this to a select since we always know what is in there.
         "type": "text",
         "name": "edit_menu_breed_version_signatures",
         "message": "What signature should be edited?",
@@ -236,6 +237,7 @@ edit_menu_breed_version_supported_arches_add = questionary.text(
 
 edit_menu_breed_version_supported_arches_edit = [
     {
+        # TODO: Change this to a select since we always know what is in there.
         "type": "text",
         "name": "edit_menu_breed_version_supported_arches_edit",
         "message": "What supported architecture shall be edited?",
@@ -256,6 +258,7 @@ edit_menu_breed_version_supported_repo_breeds_add = questionary.text(
 
 edit_menu_breed_version_supported_repo_breeds_edit = [
     {
+        # TODO: Change this to a select since we always know what is in there.
         "type": "text",
         "name": "edit_menu_breed_version_supported_repo_breeds_edit",
         "message": "What repository breed shall be edited?",
@@ -301,6 +304,7 @@ edit_menu_breed_version_boot_files_add = questionary.text(
 
 edit_menu_breed_version_boot_files_edit = [
     {
+        # TODO: Change this to a select since we always know what is in there.
         "type": "text",
         "name": "edit_menu_breed_version_boot_files_edit",
         "message": "What boot files entry shall be edited?",
@@ -380,20 +384,20 @@ def prepare_version_edit_information_os_version(version):
     :param version: The :class:`Osversion` to fetch information of.
     """
     values = [
-        "signatures - %s" % str(version.signatures),
-        "version_file - %s" % version.version_file,
-        "version_file_regex - %s" % version.version_file_regex,
-        "kernel_arch - %s" % version.kernel_arch,
-        "kernel_arch_regex - %s" % version.kernel_arch_regex,
-        "supported_arches - %s" % str(version.supported_arches),
-        "supported_repo_breeds - %s" % str(version.supported_repo_breeds),
-        "kernel_file - %s" % version.kernel_file,
-        "initrd_file - %s" % version.initrd_file,
-        "isolinux_ok - %s" % version.isolinux_ok,
-        "default_autoinstall - %s" % version.default_autoinstall,
-        "kernel_options - %s" % version.kernel_options,
-        "kernel_options_post - %s" % version.kernel_options_post,
-        "boot_files - %s" % str(version.boot_files)
+        "signatures - \"%s\"" % str(version.signatures),
+        "version_file - \"%s\"" % version.version_file,
+        "version_file_regex - \"%s\"" % version.version_file_regex,
+        "kernel_arch - \"%s\"" % version.kernel_arch,
+        "kernel_arch_regex - \"%s\"" % version.kernel_arch_regex,
+        "supported_arches - \"%s\"" % str(version.supported_arches),
+        "supported_repo_breeds - \"%s\"" % str(version.supported_repo_breeds),
+        "kernel_file - \"%s\"" % version.kernel_file,
+        "initrd_file - \"%s\"" % version.initrd_file,
+        "isolinux_ok - \"%s\"" % version.isolinux_ok,
+        "default_autoinstall - \"%s\"" % version.default_autoinstall,
+        "kernel_options - \"%s\"" % version.kernel_options,
+        "kernel_options_post - \"%s\"" % version.kernel_options_post,
+        "boot_files - \"%s\"" % str(version.boot_files)
     ]
     update_choices(edit_information_os_version, values)
 
@@ -484,6 +488,12 @@ def edit_menu():
     choice_edit_menu = edit_menu_questions.ask()
     if choice_edit_menu == "Add Operating System Breed":
         result_edit_add_os_breed = edit_add_os_breed.ask()
+        if not result_edit_add_os_breed:
+            print("Empty Operating System Breed name is not allowed. Skipping add.")
+            return
+        if result_edit_add_os_breed in [version.name for version in os_signatures.osbreeds]:
+            print("Chosen name \"%s\" already in the list of Operating System Breeds." % result_edit_add_os_breed)
+            return
         os_signatures.addosbreed(result_edit_add_os_breed)
         print("We now have %s Operating System Breeds in this file." % len(os_signatures.osbreeds))
     elif choice_edit_menu == "Remove Operating System Breed":
@@ -537,6 +547,95 @@ def edit_menu():
         print("Unknown option selected. Returning to the main menu.")
 
 
+def edit_menu_breed_version_info_signatures(my_osversion):
+    """
+    Fourth level menu to edit the ``signatures`` of an :class:`Osversion`.
+
+    :param my_osversion: The Osversion to edit.
+    """
+    result_signatures_choice = edit_menu_version_add_remove_edit.ask()
+    if result_signatures_choice == "Add":
+        new_value_signature = edit_menu_breed_version_signatures_add.ask()
+        my_osversion.signatures.add(new_value_signature)
+    elif result_signatures_choice == "Edit":
+        new_value_edit_signatures = questionary.prompt(edit_menu_breed_version_signatures_edit)
+        try:
+            my_osversion.signatures.remove(new_value_edit_signatures["edit_menu_breed_version_signatures"])
+        except KeyError:
+            print("Chosen key not found. Aborting value edit of signatures!")
+            return
+        my_osversion.signatures.add(new_value_edit_signatures["edit_menu_breed_version_signatures_new"])
+    elif result_signatures_choice == "Remove":
+        value_to_be_removed = edit_menu_breed_version_signatures_delete.ask()
+        my_osversion.signatures.remove(value_to_be_removed)
+    else:
+        print("Unknown option selected.")
+
+
+def edit_menu_breed_version_info_supported_arches(my_osversion):
+    result_supported_arches_choice = edit_menu_version_add_remove_edit.ask()
+    if result_supported_arches_choice == "Add":
+        new_value_supported_arches = edit_menu_breed_version_supported_arches_add.ask()
+        my_osversion.supported_arches.add(new_value_supported_arches)
+    elif result_supported_arches_choice == "Edit":
+        new_value_edit_arches = questionary.prompt(edit_menu_breed_version_supported_arches_edit)
+        try:
+            my_osversion.supported_arches.remove(new_value_edit_arches["edit_menu_breed_version_supported_arches_edit"])
+        except KeyError:
+            print("Chosen key not found. Aborting value edit of supported_arches!")
+            return
+        my_osversion.supported_arches.add(new_value_edit_arches["edit_menu_breed_version_supported_arches_edit_new"])
+    elif result_supported_arches_choice == "Remove":
+        value_to_be_removed = edit_menu_breed_version_supported_arches_delete.ask()
+        my_osversion.supported_arches.remove(value_to_be_removed)
+    else:
+        print("Unknown option selected.")
+    # TODO: Validation of arches (only with warning)
+
+
+def edit_menu_breed_version_info_supported_repo_breeds(my_osversion):
+    result_repo_breeds_choice = edit_menu_version_add_remove_edit.ask()
+    if result_repo_breeds_choice == "Add":
+        new_value_supported_repo_breed = edit_menu_breed_version_supported_repo_breeds_add.ask()
+        my_osversion.supported_repo_breeds.add(new_value_supported_repo_breed)
+    elif result_repo_breeds_choice == "Edit":
+        new_value_edit_supported_repo_breeds = questionary.prompt(edit_menu_breed_version_supported_repo_breeds_edit)
+        try:
+            my_osversion.supported_repo_breeds.remove(
+                new_value_edit_supported_repo_breeds["edit_menu_breed_version_supported_repo_breeds_edit"])
+        except KeyError:
+            print("Chosen key not found. Aborting value edit of supported_repo_breeds!")
+            return
+        my_osversion.supported_repo_breeds.add(
+            new_value_edit_supported_repo_breeds["edit_menu_breed_version_supported_repo_breeds_edit_new"])
+    elif result_repo_breeds_choice == "Remove":
+        value_to_be_removed = edit_menu_breed_version_supported_repo_breeds_delete.ask()
+        my_osversion.supported_repo_breeds.remove(value_to_be_removed)
+    else:
+        print("Unknown option selected.")
+    # TODO: Validation for choices (only with warning)
+
+
+def edit_menu_breed_version_info_boot_files(my_osversion):
+    result_boot_files_choice = edit_menu_version_add_remove_edit.ask()
+    if result_boot_files_choice == "Add":
+        new_value_boot_files_add = edit_menu_breed_version_boot_files_add.ask()
+        my_osversion.boot_files.add(new_value_boot_files_add)
+    elif result_boot_files_choice == "Edit":
+        new_value_edit_boot_files = questionary.prompt(edit_menu_breed_version_boot_files_edit)
+        try:
+            my_osversion.boot_files.remove(new_value_edit_boot_files["edit_menu_breed_version_boot_files_edit"])
+        except KeyError:
+            print("Chosen key not found. Aborting value edit of boot_files!")
+            return
+        my_osversion.boot_files.add(new_value_edit_boot_files["edit_menu_breed_version_boot_files_edit_new"])
+    elif result_boot_files_choice == "Remove":
+        value_to_be_removed = edit_menu_breed_version_boot_files_delete.ask()
+        my_osversion.boot_files.remove(value_to_be_removed)
+    else:
+        print("Unknown option selected.")
+
+
 def edit_menu_breed_version_info():
     """
     Third level menu to edit the information of an :class:`Osversion`.
@@ -570,21 +669,8 @@ def edit_menu_breed_version_info():
     edit_information_os_version_result = questionary.prompt(edit_information_os_version)
     choice_edit_information_os_version = edit_information_os_version_result["edit_information_os_version"]
     print(choice_edit_information_os_version)
-    if choice_edit_information_os_version == "signatures":
-        result_signatures_choice = edit_menu_version_add_remove_edit.ask()
-        if result_signatures_choice == "Add":
-            new_value_signature = edit_menu_breed_version_signatures_add.ask()
-            my_osversion.signatures.append(new_value_signature)
-        elif result_signatures_choice == "Edit":
-            new_value_edit_signatures = questionary.prompt(edit_menu_breed_version_signatures_edit)
-            index_to_change = my_osversion.signatures.index(new_value_edit_signatures)
-            my_osversion.signatures[index_to_change] = \
-                new_value_edit_signatures["edit_menu_breed_version_signatures_new"]
-        elif result_signatures_choice == "Remove":
-            value_to_be_removed = edit_menu_breed_version_signatures_delete.ask()
-            my_osversion.signatures.remove(value_to_be_removed)
-        else:
-            print("Unknown option selected.")
+    if choice_edit_information_os_version.startswith("signatures"):
+        edit_menu_breed_version_info_signatures(my_osversion)
     elif choice_edit_information_os_version.startswith("version_file"):
         new_value_version_file = edit_menu_breed_version_version_file.ask()
         my_osversion.version_file = new_value_version_file
@@ -598,40 +684,9 @@ def edit_menu_breed_version_info():
         new_value_kernel_arch_regex = edit_menu_breed_version_kernel_arch_regex.ask()
         my_osversion.kernel_arch_regex = new_value_kernel_arch_regex
     elif choice_edit_information_os_version.startswith("supported_arches"):
-        result_supported_arches_choice = edit_menu_version_add_remove_edit.ask()
-        if result_supported_arches_choice == "Add":
-            new_value_supported_arches = edit_menu_breed_version_supported_arches_add.ask()
-            my_osversion.supported_arches.append(new_value_supported_arches)
-        elif result_supported_arches_choice == "Edit":
-            new_value_edit_arches = questionary.prompt(edit_menu_breed_version_supported_arches_edit)
-            index_to_change = my_osversion.supported_arches \
-                .index(new_value_edit_arches["edit_menu_breed_version_supported_arches_edit"])
-            my_osversion.supported_arches[index_to_change] = \
-                new_value_edit_arches["edit_menu_breed_version_supported_arches_edit_new"]
-        elif result_supported_arches_choice == "Remove":
-            value_to_be_removed = edit_menu_breed_version_supported_arches_delete.ask()
-            my_osversion.supported_arches.remove(value_to_be_removed)
-        else:
-            print("Unknown option selected.")
-        # TODO: Validation of arches (only with warning)
-    elif choice_edit_information_os_version == "supported_repo_breeds":
-        result_repo_breeds_choice = edit_menu_version_add_remove_edit.ask()
-        if result_repo_breeds_choice == "Add":
-            new_value_supported_repo_breed = edit_menu_breed_version_supported_repo_breeds_add.ask()
-            my_osversion.supported_repo_breeds.append(new_value_supported_repo_breed)
-        elif result_repo_breeds_choice == "Edit":
-            new_value_edit_supported_repo_breeds = questionary.prompt(
-                edit_menu_breed_version_supported_repo_breeds_edit)
-            index_to_change = my_osversion.supported_repo_breeds.index(
-                new_value_edit_supported_repo_breeds["edit_menu_breed_version_supported_repo_breeds_edit"])
-            my_osversion.supported_repo_breeds[index_to_change] = \
-                new_value_edit_supported_repo_breeds["edit_menu_breed_version_supported_repo_breeds_edit_new"]
-        elif result_repo_breeds_choice == "Remove":
-            value_to_be_removed = edit_menu_breed_version_supported_repo_breeds_delete.ask()
-            my_osversion.supported_repo_breeds.remove(value_to_be_removed)
-        else:
-            print("Unknown option selected.")
-        # TODO: Validation for choices (only with warning)
+        edit_menu_breed_version_info_supported_arches(my_osversion)
+    elif choice_edit_information_os_version.startswith("supported_repo_breeds"):
+        edit_menu_breed_version_info_supported_repo_breeds(my_osversion)
     elif choice_edit_information_os_version.startswith("kernel_file"):
         new_value_kernel_file = edit_menu_breed_version_kernel_file.ask()
         my_osversion.kernel_file = new_value_kernel_file
@@ -652,21 +707,7 @@ def edit_menu_breed_version_info():
         new_value_kernel_options_post = edit_menu_breed_version_kernel_options_post.ask()
         my_osversion.kernel_options_post = new_value_kernel_options_post
     elif choice_edit_information_os_version.startswith("boot_files"):
-        result_boot_files_choice = edit_menu_version_add_remove_edit.ask()
-        if result_boot_files_choice == "Add":
-            new_value_boot_files_add = edit_menu_breed_version_boot_files_add.ask()
-            my_osversion.boot_files.append(new_value_boot_files_add)
-        elif result_boot_files_choice == "Edit":
-            new_value_edit_boot_files = questionary.prompt(edit_menu_breed_version_boot_files_edit)
-            index_to_change = my_osversion.boot_files \
-                .index(new_value_edit_boot_files["edit_menu_breed_version_boot_files_edit"])
-            my_osversion.boot_files[index_to_change] = \
-                new_value_edit_boot_files["edit_menu_breed_version_boot_files_edit_new"]
-        elif result_boot_files_choice == "Remove":
-            value_to_be_removed = edit_menu_breed_version_boot_files_delete.ask()
-            my_osversion.boot_files.remove(value_to_be_removed)
-        else:
-            print("Unknown option selected.")
+        edit_menu_breed_version_info_boot_files(my_osversion)
     else:
         return
     reset_edit_information_os_version()

--- a/libcobblersignatures/models/osversion.py
+++ b/libcobblersignatures/models/osversion.py
@@ -16,13 +16,13 @@ class Osversion:
         """
         Creates default values for all values.
         """
-        self._signatures = []
+        self._signatures = set()
         self._version_file = ""
         self._version_file_regex = ""
         self._kernel_arch = ""
         self._kernel_arch_regex = ""
-        self._supported_arches = []
-        self._supported_repo_breeds = []
+        self._supported_arches = set()
+        self._supported_repo_breeds = set()
         self._kernel_file = ""
         self._initrd_file = ""
         self._isolinux_ok = False
@@ -30,7 +30,7 @@ class Osversion:
         self._kernel_options = ""
         self._kernel_options_post = ""
         self._template_files = ""
-        self._boot_files = []
+        self._boot_files = set()
         self._boot_loaders = {}
 
     def __eq__(self, other) -> bool:
@@ -61,36 +61,38 @@ class Osversion:
             and self.boot_loaders == other.boot_loaders
 
     @property
-    def signatures(self) -> list:
+    def signatures(self) -> set:
         """
         This is a list of strings with currently an unknown functionality.
 
         :setter: May raise a TypeError in case the value was not of type list.
         :getter: Returns the last correctly validated str of the property.
         :deleter: Resets this to an empty list.
-        :type: list
+        :type: set
         """
         return self._signatures
 
     @signatures.setter
-    def signatures(self, value: list):
+    def signatures(self, value: set):
         """
         Setter for the signatures.
 
         :param value: The list with the signatures.
         :raises TypeError: In case the value was not of of type list.
         """
-        if isinstance(value, list):
+        if isinstance(value, set):
             self._signatures = value
+        elif isinstance(value, list):
+            self._signatures = set(value)
         else:
-            raise TypeError("Signatures should be a list.")
+            raise TypeError("Signatures should be a set.")
 
     @signatures.deleter
     def signatures(self):
         """
         Resets the value of the signatures to an emtpy list.
         """
-        self._signatures = []
+        self._signatures = set()
 
     @property
     def version_file(self) -> str:
@@ -225,61 +227,65 @@ class Osversion:
         self._kernel_arch_regex = ""
 
     @property
-    def supported_arches(self) -> list:
+    def supported_arches(self) -> set:
         """
         Unused field currently. There for compatibility reasons for now.
 
         :getter: The last successfully validated value of this field.
         :setter: Will set this if the validation succeeds, otherwise will raise an exception (TypeError).
         :deleter: Resets this to an empty list.
-        :type: list
+        :type: set
         """
         return self._supported_arches
 
     @supported_arches.setter
-    def supported_arches(self, value: list):
+    def supported_arches(self, value: set):
         """
         Setter for the supported_arches.
 
         :param value: The new list for the ``supported_arches``.
         :raises TypeError: In case value is not of type list.
         """
-        if isinstance(value, list):
+        if isinstance(value, set):
             self._supported_arches = value
+        elif isinstance(value, list):
+            self._supported_arches = set(value)
         else:
-            raise TypeError("The supported_arches should be a list.")
+            raise TypeError("The supported_arches should be a set.")
 
     @supported_arches.deleter
     def supported_arches(self):
         """
         Resets the supported_arches to an empty list instead of deleting the attribute.
         """
-        self._supported_arches = []
+        self._supported_arches = set()
 
     @property
-    def supported_repo_breeds(self) -> list:
+    def supported_repo_breeds(self) -> set:
         """
         Unused field currently. There for compatibility reasons for now.
 
         :getter: The last successfully validated value of this field.
         :setter: Will set this if the validation succeeds, otherwise will raise an exception (TypeError).
         :deleter: Resets this to an empty list.
-        :type: list
+        :type: set
         """
         return self._supported_repo_breeds
 
     @supported_repo_breeds.setter
-    def supported_repo_breeds(self, value: list):
+    def supported_repo_breeds(self, value: set):
         """
         Setter for supported_repo_breeds.
 
         :param value: The new list for the ``supported_repo_breeds``.
         :raises TypeError: In case value is not of type list.
         """
-        if isinstance(value, list):
+        if isinstance(value, set):
             self._supported_repo_breeds = value
+        elif isinstance(value, list):
+            self._supported_repo_breeds = set(value)
         else:
-            raise TypeError("The supported_repo_breeds should be a list.")
+            raise TypeError("The supported_repo_breeds should be a set.")
 
     @supported_repo_breeds.deleter
     def supported_repo_breeds(self):
@@ -514,27 +520,29 @@ class Osversion:
         self._template_files = ""
 
     @property
-    def boot_files(self) -> list:
+    def boot_files(self) -> set:
         """
         Unknown field currently. There for compatibility reasons for now. Used by xenserver
 
         :getter: The last successfully validated value of this field.
         :setter: Will set this if the validation succeeds, otherwise will raise an exception (TypeError).
         :deleter: Resets this to an empty list.
-        :type: list
+        :type: set
         """
         return self._boot_files
 
     @boot_files.setter
-    def boot_files(self, value: list):
+    def boot_files(self, value: set):
         """
         Setter for the ``boot_files``.
 
         :param value: The new boot files which should be set.
         :raises TypeError: In case value was not of type list.
         """
-        if isinstance(value, list):
+        if isinstance(value, set):
             self._boot_files = value
+        elif isinstance(value, list):
+            self._boot_files = set(value)
         else:
             raise TypeError("The boot_files should be a list.")
 
@@ -543,7 +551,7 @@ class Osversion:
         """
         Resets the boot_files to an empty list instead of deleting the attribute.
         """
-        self._boot_files = []
+        self._boot_files = set()
 
     @property
     def boot_loaders(self) -> dict:
@@ -610,7 +618,7 @@ class Osversion:
             if isinstance(value, str):
                 if value == "":
                     keys_with_defaults.append(key)
-            elif isinstance(value, (list, dict)):
+            elif isinstance(value, (list, set, dict)):
                 if len(value) == 0:
                     keys_with_defaults.append(key)
             elif isinstance(value, (bool, int)):
@@ -630,13 +638,13 @@ class Osversion:
 
         :param data: The data to decode.
         """
-        self.signatures = utils.convert_none_to_default(data.get("signatures"), list)
+        self.signatures = utils.convert_none_to_default(data.get("signatures"), set)
         self.version_file = utils.convert_none_to_default(data.get("version_file"), str)
         self.version_file_regex = utils.convert_none_to_default(data.get("version_file_regex"), str)
         self.kernel_arch = utils.convert_none_to_default(data.get("kernel_arch"), str)
         self.kernel_arch_regex = utils.convert_none_to_default(data.get("kernel_arch_regex"), str)
-        self.supported_arches = utils.convert_none_to_default(data.get("supported_arches"), list)
-        self.supported_repo_breeds = utils.convert_none_to_default(data.get("supported_repo_breeds"), list)
+        self.supported_arches = utils.convert_none_to_default(data.get("supported_arches"), set)
+        self.supported_repo_breeds = utils.convert_none_to_default(data.get("supported_repo_breeds"), set)
         self.kernel_file = utils.convert_none_to_default(data.get("kernel_file"), str)
         self.initrd_file = utils.convert_none_to_default(data.get("initrd_file"), str)
         self.isolinux_ok = utils.convert_none_to_default(data.get("isolinux_ok"), bool)
@@ -644,5 +652,5 @@ class Osversion:
         self.kernel_options = utils.convert_none_to_default(data.get("kernel_options"), str)
         self.kernel_options_post = utils.convert_none_to_default(data.get("kernel_options_post"), str)
         self.template_files = utils.convert_none_to_default(data.get("template_files"), str)
-        self.boot_files = utils.convert_none_to_default(data.get("boot_files"), list)
+        self.boot_files = utils.convert_none_to_default(data.get("boot_files"), set)
         self.boot_loaders = utils.convert_none_to_default(data.get("boot_loaders"), dict)

--- a/libcobblersignatures/utils.py
+++ b/libcobblersignatures/utils.py
@@ -5,14 +5,14 @@ Helper methods which are not directly related to any class or module in this lib
 from typing import Union
 
 
-def convert_none_to_default(value: Union[str, int, bool, list, dict, None], value_type) \
-        -> Union[str, int, bool, list, dict, None]:
+def convert_none_to_default(value: Union[str, int, bool, list, dict, set, None], value_type) \
+        -> Union[str, int, bool, list, dict, set, None]:
     """
     This method checks if the value handed to it is ``None``, otherwise the default value for the type will be returned.
 
     :param value: The value which should be checked.
     :param value_type: The type which should be returned in case the value is ``None``!
-    :return: The default value. Int: 0; str: ""; bool: False; list: []; dict: {}
+    :return: The default value. Int: 0; str: ""; bool: False; list: []; dict: {}; set: ``set()``
     :raises TypeError: In case an unknown type was selected.
     """
     if value is not None:
@@ -27,5 +27,7 @@ def convert_none_to_default(value: Union[str, int, bool, list, dict, None], valu
         return []
     elif value_type == dict:
         return {}
+    elif value_type == set:
+        return set()
     else:
         raise TypeError("The type you supplied for value_type was not known.")

--- a/tests/test_osversion.py
+++ b/tests/test_osversion.py
@@ -13,8 +13,8 @@ def test_osversion_equality():
 
 
 @pytest.mark.parametrize("param,result,raises", [
-    (["RedHat/RPMS", "CentOS/RPMS"], ["RedHat/RPMS", "CentOS/RPMS"], does_not_raise()),
-    ("", [], pytest.raises(TypeError))
+    ({"RedHat/RPMS", "CentOS/RPMS"}, {"RedHat/RPMS", "CentOS/RPMS"}, does_not_raise()),
+    ("", set(), pytest.raises(TypeError))
 ])
 def test_signatures(param, result, raises):
     # Arrange
@@ -24,8 +24,8 @@ def test_signatures(param, result, raises):
     with raises:
         version.signatures = param
 
-    # Assert
-    assert version.signatures == result
+        # Assert
+        assert version.signatures == result
 
 
 def test_signatures_del():
@@ -36,7 +36,7 @@ def test_signatures_del():
     del version.signatures
 
     # Assert
-    assert version.signatures == []
+    assert version.signatures == set()
 
 
 @pytest.mark.parametrize("param,result", [
@@ -140,7 +140,8 @@ def test_kernel_arch_regex_del():
 
 
 @pytest.mark.parametrize("param,result", [
-    (["amd64", "i386"], ["amd64", "i386"])
+    ({"amd64", "i386"}, {"amd64", "i386"}),
+    (["amd64", "i386", "amd64"], {"i386", "amd64"})
 ])
 def test_supported_arches(param, result):
     # Arrange
@@ -161,11 +162,11 @@ def test_supported_arches_del():
     del version.supported_arches
 
     # Assert
-    assert version.supported_arches == []
+    assert version.supported_arches == set()
 
 
 @pytest.mark.parametrize("param,result", [
-    (["rhn", "apt"], ["rhn", "apt"])
+    ({"rhn", "apt"}, {"rhn", "apt"})
 ])
 def test_supported_repo_breeds(param, result):
     # Arrange
@@ -378,12 +379,13 @@ def test_template_files_del():
 
 
 @pytest.mark.parametrize("param,result,raises", [
-    ("", [], pytest.raises(TypeError)),
-    (0, [], pytest.raises(TypeError)),
-    ({}, [], pytest.raises(TypeError)),
-    (None, [], pytest.raises(TypeError)),
-    (False, [], pytest.raises(TypeError)),
-    (["Element"], ["Element"], does_not_raise())
+    ("", set(), pytest.raises(TypeError)),
+    (0, set(), pytest.raises(TypeError)),
+    ({}, set(), pytest.raises(TypeError)),
+    (None, set(), pytest.raises(TypeError)),
+    (False, set(), pytest.raises(TypeError)),
+    (["Element"], {"Element"}, does_not_raise()),
+    ({"Element"}, {"Element"}, does_not_raise())
 ])
 def test_boot_files(param, result, raises):
     # Arrange
@@ -393,8 +395,8 @@ def test_boot_files(param, result, raises):
     with raises:
         version.boot_files = param
 
-    # Assert
-    assert version.boot_files == result
+        # Assert
+        assert version.boot_files == result
 
 
 def test_boot_files_del():
@@ -405,7 +407,7 @@ def test_boot_files_del():
     del version.boot_files
 
     # Assert
-    assert version.boot_files == []
+    assert version.boot_files == set()
 
 
 @pytest.mark.parametrize("param,result,raises", [


### PR DESCRIPTION
Currently if you try to edit some arrays we have in our datastructures this can lead to:

- Stacktraces in the CLI because of wrong access to the choosen data.
- Duplicates in the arrays because of missing Checks (Maybe we need to change the type to Set?)