### PR TITLE
Tests: Add tests for encoding and decoding the objects

### DIFF
--- a/libcobblersignatures/cli.py
+++ b/libcobblersignatures/cli.py
@@ -532,6 +532,7 @@ def edit_menu():
         name_to_find = result_edit_remove_os_version_1["edit_remove_os_version_1"]
         index = os_signatures.get_breed_index_by_name(name_to_find)
         if index != -1 and name_to_find == os_signatures.osbreeds[index].name:
+            update_choices(edit_remove_os_version_2, get_os_version_names(name_to_find))
             result_edit_remove_os_version_2 = questionary.prompt(edit_remove_os_version_2)
             name_to_find_1 = result_edit_remove_os_version_2["edit_remove_os_version_2"]
             os_signatures.removeosversion(index, name_to_find_1)

--- a/libcobblersignatures/models/osversion.py
+++ b/libcobblersignatures/models/osversion.py
@@ -615,6 +615,11 @@ class Osversion:
 
         for key in interim_result:
             value = interim_result[key]
+
+            # Convert non JSON convertable sets to convertable lists
+            if isinstance(value, set):
+                interim_result[key] = list(value)
+
             if isinstance(value, str):
                 if value == "":
                     keys_with_defaults.append(key)

--- a/tests/test_osbreed.py
+++ b/tests/test_osbreed.py
@@ -104,3 +104,32 @@ def test_breed_remove():
 
     # Act & Assert
     osbreed.osversion_remove(itemname)
+
+
+def test_encode():
+    # Arrange
+    breed = OsBreed("test")
+    breed.osversion_add("test1", Osversion())
+    breed.osversion_add("test2", Osversion())
+
+    # Act
+    result = breed.encode()
+
+    # Assert
+    assert isinstance(result, dict)
+    assert "test1" in result
+    assert "test2" in result
+    assert isinstance(result["test1"], dict)
+
+
+def test_decode():
+    # Arrange
+    breed = OsBreed("test")
+    data = {"version1": {}, "version2": {}}
+
+    # Act
+    breed.decode(data)
+
+    # Assert
+    assert breed.osversions["version1"]
+    assert breed.osversions["version2"]

--- a/tests/test_osversion.py
+++ b/tests/test_osversion.py
@@ -439,3 +439,42 @@ def test_boot_loaders_del():
 
     # Assert
     assert version.boot_loaders == {}
+
+
+def test_encode():
+    # Arrange
+    version = Osversion()
+
+    # Act
+    result = version.encode()
+
+    # Assert
+    assert isinstance(result, dict)
+    # If we have an empty version, only the bools are shown.
+    assert len(result) == 1
+
+
+def test_encode_set():
+    # Arrange
+    version = Osversion()
+    version.signatures.add("test")
+
+    # Act
+    result = version.encode()
+
+    # Assert
+    assert isinstance(result, dict)
+    # If we have an empty version, only the bools are shown.
+    assert len(result) == 2
+
+
+def test_decode():
+    # Arrange
+    version = Osversion()
+    data = {"version_file": "test"}
+
+    # Act
+    version.decode(data)
+
+    # Assert
+    assert version.version_file == "test"


### PR DESCRIPTION
This also includes a fix for osversion which is required because the conversion to set() from list() broke the export.