### PR TITLE
Add Ubuntu 23.10

### DIFF
--- a/changelog.d/70.added
+++ b/changelog.d/70.added
@@ -1,0 +1,1 @@
+Added support for Ubuntu 23.10

--- a/libcobblersignatures/data/v2/distro_signatures.json
+++ b/libcobblersignatures/data/v2/distro_signatures.json
@@ -1897,6 +1897,32 @@
         "template_files": "",
         "boot_files": [],
         "boot_loaders": {}
+       },
+      "mantic": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: mantic|Ubuntu 23.10",
+        "kernel_arch": "linux_headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
       }
     },
     "suse": {


### PR DESCRIPTION
Add Ubuntu 23.10 to supported distros

Fixes: https://github.com/cobbler/libcobblersignatures/issues/70