### PR TITLE
fix link to hosted signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ Can be found in our Docs: <https://libcobblersignatures.readthedocs.io>
 
 The JSON Schema and an example can be found at
 
-* <https://cobbler.github.io/libcobblersignatures/data/<version>/schema.json >
-* <https://cobbler.github.io/libcobblersignatures/data/<version>/distro_signatures.json >
+* https<nolink>://cobbler.github.io/libcobblersignatures/data/\<version>/schema.json (
+[latest schema](https://cobbler.github.io/libcobblersignatures/data/v2/schema.json) )
+
+* https<nolink>://cobbler.github.io/libcobblersignatures/data/\<version>/distro_signatures.json (
+[latest signatures](https://cobbler.github.io/libcobblersignatures/data/v2/distro_signatures.json) )
 
 
 | version | cobbler_version |


### PR DESCRIPTION
This PR improves the way the links to the hosted signatures on `cobbler.github.io` are displayed. 

Here a screenshot of the preview from VSCode
![Screenshot_20240404_174017](https://github.com/cobbler/libcobblersignatures/assets/100686237/abd55921-0941-4d02-a7b7-604cb917e16b)
