### PR TITLE
specify list of valid repo breeds in schema

### DIFF
--- a/changelog.d/69.fixed
+++ b/changelog.d/69.fixed
@@ -1,0 +1,1 @@
+Specified list of valid repo breeds in the signatures schema

--- a/libcobblersignatures/data/v2/schema.json
+++ b/libcobblersignatures/data/v2/schema.json
@@ -71,7 +71,13 @@
                           "description": "",
                           "type": "array",
                           "items": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                              "rsync",
+                              "rhn",
+                              "yum",
+                              "apt"
+                            ]
                           }
                         },
                         "kernel_file": {


### PR DESCRIPTION
This PR adds a list of valid repo breeds to the distro signatures schema to better indicate which repo breeds are supported by cobbler

Fixes: https://github.com/cobbler/libcobblersignatures/issues/69